### PR TITLE
Fixed typo and translated untranslated parts in korean translation

### DIFF
--- a/kor/lang.ini
+++ b/kor/lang.ini
@@ -72,7 +72,7 @@ potion.hunger=배고픔
 potion.weakness=피해 약화
 potion.poison=독
 potion.wither=위더
-potion.healthBoost=채력 강화
+potion.healthBoost=체력 강화
 potion.absorption=흡수
 potion.saturation=포화
 
@@ -306,7 +306,7 @@ nukkit.command.time.usage=/time <set|add> <값> 또는 /time <start|stop|query>
 nukkit.command.gamerule.description=게임 규칙 값을 설정 또는 쿼리합니다
 nukkit.command.gamerule.usage=/gamerule <rule> [value]
 
-nukkit.command.debug.description=Uploads server information to Hastebin
+nukkit.command.debug.description=Hastebin에 서버 정보를 업로드합니다
 nukkit.command.debug.usage=/debugpaste
 
 nukkit.command.ban.player.description=지정된 플레이어가 이 서버를 이용하지 못하도록 합니다

--- a/kor/nukkit.yml
+++ b/kor/nukkit.yml
@@ -6,7 +6,7 @@ settings:
  #다국어 설정
  #사용 가능: eng, chs, cht, jpn, rus, spa, pol, bra, kor, ukr, deu, ltu, cze
  language: "kor"
- #모든 문자열을 서버 로캘로 번역해 전송하거나 기기가 처리할 수 있게 할지 여부
+ #모든 문자열을 서버 언어로 번역해 전송하거나 기기가 처리할 수 있게 할지 여부
  force-language: false
  shutdown-message: "Server closed"
  #Query를 통한 플러그인 목록 보기를 허용합니다
@@ -29,7 +29,7 @@ network:
 debug:
  #1보다 크면, 콘솔에 디버그 메시지를 표시합니다
  level: 1
- #명령어를 활성화합니다: /status /gc
+ #다음 명령어를 활성화합니다: /status /gc
  commands: false
 
 timings:
@@ -55,9 +55,9 @@ timings:
  ignore: []
 
 level-settings:
- #레벨이 생성될 때 사용할 기본 포맷
+ #세계가 생성될 때 사용할 기본 포맷
  default-format: mcregion
- #1초당 20틱을 유지하기 위해 자동으로 레벨의 틱을 변경합니다
+ #1초당 20틱을 유지하기 위해 자동으로 세계의 틱을 변경합니다
  auto-tick-rate: true
  auto-tick-rate-limit: 20
  #기본 틱을 설정합니다 (1 = 1초당 20틱, 2 = 1초당 10틱, 등등.)
@@ -97,7 +97,7 @@ ticks-per:
  cache-cleanup: 900
 
 spawn-limits:
- #이 개체들의 최대 생성량
+ #다음 개체들의 최대 생성량
  monsters: 70
  animals: 15
  water-animals: 5
@@ -107,7 +107,7 @@ player:
  #true로 설정하면, 플레이어 데이터가 players/플레이어 이름.dat으로 저장됩니다
  #false로 설정하면, Nukkit이 플레이어 데이터를 "dat" 파일로 저장하지 않으므로 플러그인에서 무언가를 수행할 수 있습니다.
  save-player-data: true
- #The time between skin change action in seconds, set to 0 if you dont want the cooldown
+ #스킨 변경 동작 사이의 쿨 다운(초), 쿨 다운을 원하지 않는 경우 0으로 설정하세요
  skin-change-cooldown: 30
  
 aliases:
@@ -117,8 +117,7 @@ aliases:
  # savestop: [save-all, stop]
 
 worlds:
- #Worlds that the server will use. Options are specific to the chosen generator, and may result in broken generation or
- #be ignored completely.
+ #서버가 사용할 세계. 옵션은 선택한 생성기에 따라 다르며 생성이 중단되거나 완전히 무시 될 수 있습니다.
  world:
   seed: 404
   generator: normal


### PR DESCRIPTION
Changed all `레벨` words to `세계`
`채력 강화` -> `체력 강화`
`로캘` -> `언어`
